### PR TITLE
Update 12.faq.md

### DIFF
--- a/zh-CN/4.user-guide-2/12.faq.md
+++ b/zh-CN/4.user-guide-2/12.faq.md
@@ -12,7 +12,7 @@ A：您可以通过其他具有 OCP 用户管理权限的账号，修改 Admin �
 
 **Q2：OCP 登录的账号密码？**
 
-A：OCP 默认的账号为 `admin`， 默认密码为 `root`，强烈建议您第一次登陆之后修改 Admin 用户的密码并牢记。
+A：OCP 默认的账号为 `admin`， 默认密码为 `aaAA11__`，强烈建议您第一次登陆之后修改 Admin 用户的密码并牢记。
 
 具体操作，请参见 [修改用户密码](10.system-management-features/9.change-user-password.md)。
 


### PR DESCRIPTION
社区版本部署OCP的文档找见一个问题
https://www.oceanbase.com/docs/community-ocp-cn-10000000000866616 这个文档里面显示admin密码默认是 aaAA11__
----
但是在常见问题里面
https://www.oceanbase.com/docs/community-ocp-cn-10000000000866598 这个文档里面显示admin密码默认是 root

<!--
Thank you for contributing to **OceanBase**! Please read the [How to Contribute](https://github.com/oceanbase/oceanbase/wiki/how_to_contribute) document **BEFORE** filing this PR.
-->

### What changes were proposed in this pull request?

更改内容： [OCP部署常见问题](https://www.oceanbase.com/docs/community-ocp-cn-10000000000866598) 文档里面admin密码默认值写错了

### Why are the changes needed?

非常重要：对于阅读文档的用户这里会坑一下用户。让查看文档的用户体验变差，感到纳闷。

### Will break the compatibility? How if so?

不会影响兼容性

### Does this PR introduce any user-facing change?

yes

### How was this patch tested?

只修改了文档...没有修改代码,肉眼观察的

### Checklist
<!--Tick the checkbox(es) below to choose what you have done.-->

- [x] I've run the tests to see all new and existing tests pass.
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above.
- [x] I've informed the technical writer about the documentation change if necessary.